### PR TITLE
tests: add unit tests for Merge Sort (Python) and minimal implementation

### DIFF
--- a/algorithms/sorting/merge_sort/python/merge_sort.py
+++ b/algorithms/sorting/merge_sort/python/merge_sort.py
@@ -1,0 +1,25 @@
+def merge_sort(arr):
+    """Return a new list with the elements of ``arr`` sorted in ascending order."""
+    if arr is None:
+        return None
+    if len(arr) <= 1:
+        return list(arr)
+
+    def _merge(left, right):
+        i = j = 0
+        merged = []
+        while i < len(left) and j < len(right):
+            if left[i] <= right[j]:
+                merged.append(left[i])
+                i += 1
+            else:
+                merged.append(right[j])
+                j += 1
+        merged.extend(left[i:])
+        merged.extend(right[j:])
+        return merged
+
+    mid = len(arr) // 2
+    left = merge_sort(arr[:mid])
+    right = merge_sort(arr[mid:])
+    return _merge(left, right)

--- a/algorithms/sorting/merge_sort/python/test_merge_sort.py
+++ b/algorithms/sorting/merge_sort/python/test_merge_sort.py
@@ -1,0 +1,38 @@
+import unittest
+from merge_sort import merge_sort
+
+
+class TestMergeSort(unittest.TestCase):
+    def test_odd_length_unsorted(self):
+        arr = [3, 1, 4, 5, 2]
+        expected = sorted(arr)
+        self.assertEqual(merge_sort(arr), expected)
+
+    def test_even_length_unsorted(self):
+        arr = [8, 4, 2, 7, 1, 3]
+        expected = sorted(arr)
+        self.assertEqual(merge_sort(arr), expected)
+
+    def test_already_sorted(self):
+        arr = [1, 2, 3, 4, 5]
+        expected = arr.copy()
+        self.assertEqual(merge_sort(arr), expected)
+
+    def test_duplicates(self):
+        arr = [4, 1, 3, 4, 2, 1]
+        expected = sorted(arr)
+        self.assertEqual(merge_sort(arr), expected)
+
+    def test_empty_list(self):
+        arr = []
+        expected = []
+        self.assertEqual(merge_sort(arr), expected)
+
+    def test_single_element(self):
+        arr = [42]
+        expected = [42]
+        self.assertEqual(merge_sort(arr), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added a minimal, correct Merge Sort implementation and a focused unittest suite to validate common cases: odd/even-length lists, already-sorted input, duplicates, an empty list, and a single element. Tests live at algorithms/sorting/merge_sort/python/test_merge_sort.py and the implementation at algorithms/sorting/merge_sort/python/merge_sort.py. 
Closes #133.