### PR TITLE
Bubble Sort algorithm in Rust (with unit tests)

### DIFF
--- a/algorithms/sorting/bubble_sort/rust/bubble_sort.rs
+++ b/algorithms/sorting/bubble_sort/rust/bubble_sort.rs
@@ -1,0 +1,76 @@
+use std::io;
+
+/// Bubble Sort function
+/// Sorts a mutable slice in ascending order
+fn bubble_sort<T: PartialOrd>(arr: &mut [T]) {
+    let n = arr.len();
+    // Traverse through all array elements
+    for i in 0..n {
+        // Last i elements are already in place
+        for j in 0..(n - i - 1) {
+            if arr[j] > arr[j + 1] {
+                arr.swap(j, j + 1); // Swap if the element found is greater than next
+            }
+        }
+    }
+}
+
+fn main() {
+    println!("Enter numbers separated by spaces:");
+
+    let mut input = String::new();
+    io::stdin()
+        .read_line(&mut input)
+        .expect("Failed to read input");
+
+    // Parse input into a vector of integers
+    let mut numbers: Vec<i32> = input
+        .trim()
+        .split_whitespace()
+        .map(|x| x.parse::<i32>().expect("Invalid number"))
+        .collect();
+
+    println!("Before sorting: {:?}", numbers);
+    bubble_sort(&mut numbers);
+    println!("After sorting:  {:?}", numbers);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_array() {
+        let mut arr: [i32; 0] = [];
+        bubble_sort(&mut arr);
+        assert_eq!(arr, []);
+    }
+
+    #[test]
+    fn test_sorted_array() {
+        let mut arr = [1, 2, 3, 4, 5];
+        bubble_sort(&mut arr);
+        assert_eq!(arr, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_unsorted_array() {
+        let mut arr = [5, 3, 4, 1, 2];
+        bubble_sort(&mut arr);
+        assert_eq!(arr, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_duplicates() {
+        let mut arr = [3, 1, 2, 3, 2];
+        bubble_sort(&mut arr);
+        assert_eq!(arr, [1, 2, 2, 3, 3]);
+    }
+
+    #[test]
+    fn test_negative_numbers() {
+        let mut arr = [0, -1, 3, -2, 2];
+        bubble_sort(&mut arr);
+        assert_eq!(arr, [-2, -1, 0, 2, 3]);
+    }
+}


### PR DESCRIPTION
Fixes #290

The code sorts a mutable slice of numbers in ascending order and includes a runnable example as well as unit tests.

Key points:
- Implements `bubble_sort` function that takes a mutable slice (&mut [T]) and sorts it in place.
- Fully commented for clarity and follows standard Rust conventions.
- Includes a `main` function allowing the user to input numbers and see the sorted output.

Unit tests are provided using Rust’s #[test] framework:
- Empty array
- Already sorted array
- Unsorted array
- Array with duplicates
- Array with negative numbers

