### PR TITLE
fix(ci): Remove --exit-zero from flake8 to enable PR failures

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           echo "Running flake8..."
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88 --statistics
+          flake8 . --count --max-complexity=10 --max-line-length=88 --statistics
 
       # Step 5: Run black in check mode
       - name: Run black (format check)


### PR DESCRIPTION
## Description

This pull request fixes a critical bug in the Python linting workflow (`lint-python.yml`) that was introduced in PR #311.

The workflow was using the `--exit-zero` flag with `flake8`, which caused the linter step to always report success, even when it found style errors. This made the automated check ineffective.

## Changes Made

-   Removed the `--exit-zero` flag from the `flake8` command in the `lint-python.yml` workflow file.

This ensures that the job will now correctly fail if `flake8` detects any style issues, properly enforcing our project's coding standards.

## Related Issue

This fixes a bug introduced during the resolution of issue #291 .