### PR TITLE
automation: add GitHub Action to check for outdated PRs

### DIFF
--- a/.github/workflows/check-pr-sync.yml
+++ b/.github/workflows/check-pr-sync.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   pull-requests: write
   contents: read
+  issues: write
 
 jobs:
   check-sync:
@@ -48,7 +49,6 @@ jobs:
       - name: Post comment if behind
         if: steps.check-behind.outputs.behind == 'true'
         uses: actions/github-script@v7
-        continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Add GitHub Action to Check for Outdated PRs

### Description
This PR implements an automated GitHub Action workflow that checks if pull request branches are behind the main branch and posts helpful sync instructions when needed.

### Changes Made
- ✅ Created `.github/workflows/check-pr-sync.yml`
- ✅ Workflow triggers on PR opened, synchronize, and reopened events
- ✅ Automatically detects when PR branch is behind main
- ✅ Posts informative comment with sync instructions (both GitHub UI and Git CLI methods)
- ✅ Smart comment management (updates existing comment instead of creating duplicates)
- ✅ Includes commit count to show how far behind the branch is

### Related Issue
Fixes #212

### Type of Change
- [x] New feature (automation/workflow)

### How It Works

**When a PR is opened or updated:**
1. The action checks out the PR branch
2. Fetches the latest main branch
3. Compares commit history using `git merge-base`
4. If the PR branch is behind main:
   - Calculates number of commits behind
   - Posts (or updates) a helpful comment with sync instructions
5. If the PR branch is up-to-date:
   - Does nothing (silent success)

### Example Comment Output

When a PR is behind, contributors will see:

> Hi @uptouplaksh , thank you for this pull request! 👋
>
> Our automated check has detected that your branch is **5 commit(s) behind** our `main` branch...
>
> [Followed by clear sync instructions using both GitHub UI and Git commands]

### Testing
- ✅ Workflow file syntax validated
- ✅ Uses latest GitHub Actions versions (checkout@v4, github-script@v7)
- ✅ Proper permissions configured (pull-requests: write, contents: read)
- ✅ Prevents duplicate comments through smart detection

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added comments where necessary
- [x] The workflow file is properly formatted
- [x] All acceptance criteria from the issue are met