### PR TITLE
Add Python linting workflow for pull requests

### DIFF
--- a/.github/workflows/.github/workflows/lint.yml
+++ b/.github/workflows/.github/workflows/lint.yml
@@ -1,0 +1,50 @@
+name: Python Linting on PR
+
+on:
+  pull_request:
+    branches:
+      - main # or your default branch
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Fetch depth 0 ensures we get the full history needed for git diff
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x' # Choose your desired Python version
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 # Install the linter
+
+      # 1. Get changed Python files
+      - name: Get changed Python files
+        id: files
+        run: |
+          # Use git diff to find files changed between the merge-base (or 'before') 
+          # and the current commit (github.sha).
+          # '|| true' ensures the step doesn't fail if no .py files are changed.
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.py$' || true)
+          echo "Changed Python Files: $CHANGED_FILES"
+          echo "files=$CHANGED_FILES" >> $GITHUB_OUTPUT
+        # Note: The original example uses '::set-output', which is deprecated.
+        # This modern version uses '$GITHUB_OUTPUT'.
+
+      # 2. Run flake8 on changed files
+      - name: Run flake8 on changed files
+        # Check if the output variable 'files' is NOT empty.
+        if: steps.files.outputs.files != ''
+        run: |
+          echo "Running flake8 on the following files:"
+          echo "${{ steps.files.outputs.files }}"
+          # The 'flake8' command receives the list of files as a single string 
+          # and processes them correctly.
+          flake8 ${{ steps.files.outputs.files }}


### PR DESCRIPTION
## Description and Changes made

This PR introduces a new **GitHub Actions workflow for Python linting** using `flake8`.

The workflow, defined in `.github/workflows/lint.yml`, is configured to run automatically on all new Pull Requests. Crucially, it uses `git diff` to **lint only the files that have been changed or added** in the current PR, rather than linting the entire codebase. This prevents existing errors in untouched, older files from blocking new contributions.

issue number: #291 


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary (Comments added to the GitHub Actions code explaining the `git diff` and output logic)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (N/A for workflow file, but general code integrity is maintained)
- [x] I have added documentation wherever appropriate (The workflow itself serves as a piece of configuration documentation)

