### PR TITLE
chore(ci): Change contributor update to a daily schedule

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,9 +1,9 @@
 name: Update Contributors
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    # This runs once every day at midnight UTC (around 5:30 AM in India).
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

This PR fixes a recurring merge conflict issue caused by the `update-contributors` workflow.

The workflow was previously configured to run on every push to `main`. This immediately made all other open pull requests outdated and frequently caused merge conflicts in the `CONTRIBUTORS.md` file, creating extra work for both the maintainer and contributors.

## Changes Made

-   Changed the trigger in `.github/workflows/update-contributors.yml` from `on: push` to `on: schedule`.
-   The action will now run once per day, which will "batch" updates to the contributors list and significantly reduce the frequency of merge conflicts.