### PR TITLE
fix: switch to pull_request_target for label permission access

### DIFF
--- a/.github/workflows/auto-labeler-hacktoberfest.yml
+++ b/.github/workflows/auto-labeler-hacktoberfest.yml
@@ -1,7 +1,7 @@
 name: "Label merged PRs as hacktoberfest-accepted"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:


### PR DESCRIPTION
## Description and Changes made

The auto-labeler workflow was failing with the error
RequestError [HttpError]: Resource not accessible by integration
whenever a PR was merged.

Cause:
The workflow was triggered using the pull_request event, which restricts the GITHUB_TOKEN permissions for forked repositories, preventing label modification.

Changes made:
-Updated the workflow trigger from pull_request → pull_request_target.
-This ensures the workflow runs in the base repository context, allowing it to create and add the hacktoberfest-accepted label successfully.

## Related Issue

Closes #374 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added documentation wherever appropriate

## Screenshots (if applicable)

N/A — this change affects the GitHub Actions workflow (no UI changes).

## Additional Notes

-The pull_request_target event safely runs in the main repo context with the required permissions.
-The workflow now successfully applies the hacktoberfest-accepted label on merged PRs.